### PR TITLE
Stub for unittests and coveralls CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip-compile
   - pip install -r requirements.txt
 script:
-  - py.test --cov
+  - python -m py.test --cov=core
 after_success:
   - coveralls
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Pyrate
 Optical Design with Python.
 
 [![Build Status](https://travis-ci.org/theinze/pyrate.svg?branch=master)](https://travis-ci.org/theinze/pyrate)
+[![Coverage Status](https://coveralls.io/repos/github/theinze/pyrate/badge.svg?branch=master)](https://coveralls.io/github/theinze/pyrate?branch=master)
 
 To use the core package with standard management and optimization code
 write your source file and import the modules from the core subdirectory.

--- a/core/stub.py
+++ b/core/stub.py
@@ -1,0 +1,2 @@
+def func(x):
+    return x + 1

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,5 +1,0 @@
-def func(x):
-    return x + 1
-
-def test_answer():
-    assert func(3) == 4 

--- a/tests/test_stub.py
+++ b/tests/test_stub.py
@@ -1,0 +1,4 @@
+from core.stub import func
+
+def test_stub():
+    assert func(41) == 42


### PR DESCRIPTION
Created a unittest stub `core/stub.py`, `tests/test_stub.py` for the `core` package and [coveralls CI](https://coveralls.io/) (i.e., lines covered by unittests, currently [![Coverage Status](https://coveralls.io/repos/github/theinze/pyrate/badge.svg?branch=master)](https://coveralls.io/github/theinze/pyrate?branch=master)

Note: For Travis and coveralls.io, you need to allow travis and coveralls to access your github repository: [Step 1 and 2, step 3, 4, 5 already done, see `.travis.yml`](https://docs.travis-ci.com/user/getting-started/) and [coveralls](https://coveralls.zendesk.com/hc/en-us), You would also need to adjust the badges in `README.md` to your github respository