### PR TITLE
Fixed error in demo scripts

### DIFF
--- a/demo_mirrors.py
+++ b/demo_mirrors.py
@@ -2,9 +2,10 @@
 """
 Pyrate - Optical raytracing based on Python
 
-Copyright (C) 2014 Moritz Esslinger moritz.esslinger@web.de
-               and Johannes Hartung j.hartung@gmx.net
-               and    Uwe Lippmann  uwe.lippmann@web.de
+Copyright (C) 2017 Moritz Esslinger <moritz.esslinger@web.de>
+               and Johannes Hartung <j.hartung@gmx.net>
+               and     Uwe Lippmann <uwe.lippmann@web.de>
+               and    Thomas Heinze <t.heinze@fn.de>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -35,7 +36,7 @@ from core.surface import Surface
 from core.ray import RayBundle
 
 from core.aperture import CircularAperture
-from core.coordinates import LocalCoordinates
+from core.localcoordinates import LocalCoordinates
 
 from core.globalconstants import canonical_ey
 

--- a/demo_optimize.py
+++ b/demo_optimize.py
@@ -2,9 +2,10 @@
 """
 Pyrate - Optical raytracing based on Python
 
-Copyright (C) 2014 Moritz Esslinger moritz.esslinger@web.de
-               and Johannes Hartung j.hartung@gmx.net
-               and    Uwe Lippmann  uwe.lippmann@web.de
+Copyright (C) 2017 Moritz Esslinger <moritz.esslinger@web.de>
+               and Johannes Hartung <j.hartung@gmx.net>
+               and     Uwe Lippmann <uwe.lippmann@web.de>
+               and    Thomas Heinze <t.heinze@fn.de>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -32,7 +33,7 @@ from core.ray import RayPath, RayBundle
 
 from core import plots
 from core.aperture import CircularAperture, BaseAperture
-from core.coordinates import LocalCoordinates
+from core.localcoordinates import LocalCoordinates
 
 from core.globalconstants import standard_wavelength
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -39,5 +39,9 @@ def test_smoke_doublet():
 
 def test_smoke_mirror():
     """Smoke test based on demo_mirrors.py."""
-    # import demo_mirrors # TODO
+    import demo_mirrors
+    assert True
+def test_smoke_optimize():
+    """Smoke test based on demo_optimize.py."""
+    import demo_optimize
     assert True


### PR DESCRIPTION
There were imports using old dependences in both scripts `demo_mirrors.py` and `demo_optimize.py`,  I have fixed this issue, so that both scripts seem to be working again. I also added scripts to the smoke test.

Note, the scripts may have still be working on your site, since you still got the `*.pyc` of the old dependences in your local installation. Just try to remove them, i.e., `rm *.pyc`, and run the scripts, you will end up with the following exception:
```
$ python demo_mirrors.py
Traceback (most recent call last):
  File "demo_mirrors.py", line 38, in <module>
    from core.coordinates import LocalCoordinates
ImportError: No module named coordinates
```
:-)