### PR TITLE
Updated CI to nose2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
   - pip install -U pip pip-tools setuptools
   - pip-compile                       # requirements.in -> requirements.txt
   - pip install -r requirements.in  # install pyrate dependences
+  - pip install nose2[coverage_plugin] # coverage plugin (does not seem to
+                                       # to work with requirements.in ???)
 script:
   - python -m nose2 --with-coverage --cover-package=pyrateoptics tests.smoke_test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   # travis CI uses x64 VMs, python builds not available for OSX
-  - "2.7"
+  - "3.6"
 addons:
   apt:
     packages:
@@ -11,9 +11,9 @@ addons:
 install:
   - pip install -U pip pip-tools setuptools
   - pip-compile                       # requirements.in -> requirements.txt
-  - pip install -r requirements.txt   # install pyrate dependences
+  - pip install -r requirements.in  # install pyrate dependences
 script:
-  - python -m nose --with-coverage --cover-package=pyrateoptics tests.smoke_test
+  - python -m nose2 --with-coverage --cover-package=pyrateoptics tests.smoke_test
 after_success:
   - coveralls     # submit test coverage information to coveralls.io
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ install:
   - pip install -U pip pip-tools setuptools
   - pip-compile                       # requirements.in -> requirements.txt
   - pip install -r requirements.in  # install pyrate dependences
-  - pip install nose2[coverage_plugin] # coverage plugin (does not seem to
-                                       # to work with requirements.in ???)
 script:
-  - python -m nose2 --with-coverage --cover-package=pyrateoptics tests.smoke_test
+  - python -m nose2 --with-coverage --coverage=pyrateoptics/ tests.smoke_test
 after_success:
   - coveralls     # submit test coverage information to coveralls.io
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,6 @@ install:
   - conda update -q conda
   - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy matplotlib pytest"
   - activate test-environment
-  - pip install -U --user pip pip-tools
-  - pip-compile                       # requirements.in -> requirements.txt
   - pip install -r requirements.in   # install pyrate dependences
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - conda update -q conda
   - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy matplotlib pytest"
   - activate test-environment
-  - pip install -U pip pip-tools
+  - pip install -U --user pip pip-tools
   - pip-compile                       # requirements.in -> requirements.txt
   - pip install -r requirements.in   # install pyrate dependences
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
-build: false
+build: off
 
 environment:
   matrix:
     - platform: x86
-      PYTHON_ROOT: "C:\\Python27"
-      PYTHON_VERSION: "2.7"
+      PYTHON_ROOT: "C:\\Python36"
+      PYTHON_VERSION: "3.6"
       MINICONDA: "C:\\Miniconda"
     - platform: x64
-      PYTHON_ROOT: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7"
+      PYTHON_ROOT: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
       MINICONDA: "C:\\Miniconda-x64"
 
 install:
@@ -20,7 +20,7 @@ install:
   - activate test-environment
   - pip install -U pip pip-tools
   - pip-compile                       # requirements.in -> requirements.txt
-  - pip install -r requirements.txt   # install pyrate dependences
+  - pip install -r requirements.in   # install pyrate dependences
 
 test_script:
-  - python -m nose  tests.smoke_test # test automation, no coverage
+  - python -m nose2 tests.smoke_test # test automation, no coverage

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ scipy # pyrate dependency
 sympy # pyrate dependency
 matplotlib # pyrate dependency
 pyyaml # pyrate dependency
-nose2[coverage_plugin] # test automation with nose2
+nose2[coverage_plugin] # test automation
 hypothesis # quickcheck
 coverage # test coverage
 coveralls # coveralls.io CI

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ scipy # pyrate dependency
 sympy # pyrate dependency
 matplotlib # pyrate dependency
 pyyaml # pyrate dependency
-nose2[coverage_plugin] # test automation
+nose2 # test automation
 hypothesis # quickcheck
 coverage # test coverage
 coveralls # coveralls.io CI

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ scipy # pyrate dependency
 sympy # pyrate dependency
 matplotlib # pyrate dependency
 pyyaml # pyrate dependency
-nose2 # test automation
+nose2[coverage_plugin] # test automation
 hypothesis # quickcheck
 coverage # test coverage
 coveralls # coveralls.io CI

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ scipy # pyrate dependency
 sympy # pyrate dependency
 matplotlib # pyrate dependency
 pyyaml # pyrate dependency
-nose2[coverage_plugin] # test automation
+nose2[coverage_plugin] # test automation with nose2
 hypothesis # quickcheck
 coverage # test coverage
 coveralls # coveralls.io CI

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ scipy # pyrate dependency
 sympy # pyrate dependency
 matplotlib # pyrate dependency
 pyyaml # pyrate dependency
-nose # test automation
+nose2 # test automation
 hypothesis # quickcheck
 coverage # test coverage
 coveralls # coveralls.io CI


### PR DESCRIPTION
I've updated the CI configuration scripts (Travis CI and Appveyor and Coveralls) to nose2 from nose. Should be working now.

However, there is not much testing going on currently :-)

If you prefer another testing framework (tox, ...), just let me know, though, nose2 is currenlty just used for running the CI tests and nothing else, I think.

Btw. The badges in the README.md file are currently pointing to my forked repository, you may want to update them to your repository when merging.